### PR TITLE
Add advertisement banners alongside filter panel

### DIFF
--- a/src/components/FilterList/FilterList.js
+++ b/src/components/FilterList/FilterList.js
@@ -5,17 +5,49 @@ import "./FilterList.scss";
 
 function FilterList() {
   const filterIds = [1, 2, 3, 4, 5];
+
+  const advertisements = {
+    left: {
+      href: "https://www.emirates.com/ru/russian/",
+      img: "https://images.unsplash.com/photo-1549921296-3ecf9c9e3be0?auto=format&fit=crop&w=400&q=80",
+      alt: "Emirates — специальные тарифы на дальнемагистральные рейсы",
+    },
+    right: {
+      href: "https://www.qatarairways.com/ru-ru/homepage.html",
+      img: "https://images.unsplash.com/photo-1529074963764-98f45c47344b?auto=format&fit=crop&w=400&q=80",
+      alt: "Qatar Airways — комфортные перелёты в любую точку мира",
+    },
+  };
+
   return (
-    <aside className="filter">
-      <h3>Количество пересадок</h3>
-      <ul className="filter__list">
-        {filterIds.map((id) => (
-          <li className="filter__item" key={id}>
-            <Filter id={id} />
-          </li>
-        ))}
-      </ul>
-    </aside>
+    <div className="filter-layout">
+      <a
+        className="filter-layout__ad filter-layout__ad--left"
+        href={advertisements.left.href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={advertisements.left.img} alt={advertisements.left.alt} />
+      </a>
+      <aside className="filter">
+        <h3>Количество пересадок</h3>
+        <ul className="filter__list">
+          {filterIds.map((id) => (
+            <li className="filter__item" key={id}>
+              <Filter id={id} />
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <a
+        className="filter-layout__ad filter-layout__ad--right"
+        href={advertisements.right.href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={advertisements.right.img} alt={advertisements.right.alt} />
+      </a>
+    </div>
   );
 }
 export default FilterList;

--- a/src/components/FilterList/FilterList.scss
+++ b/src/components/FilterList/FilterList.scss
@@ -1,3 +1,31 @@
+.filter-layout {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.filter-layout__ad {
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  display: block;
+  max-width: 320px;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+
+  img {
+    display: block;
+    height: 200px;
+    object-fit: cover;
+    width: 100%;
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+  }
+}
+
 .filter__list {
   display: flex;
   flex-flow: row wrap;
@@ -30,6 +58,22 @@
 }
 
 @media (min-width: 768px) {
+  .filter-layout {
+    align-items: flex-start;
+    display: grid;
+    gap: 24px;
+    grid-template-columns: 120px auto 120px;
+    justify-items: center;
+  }
+
+  .filter-layout__ad {
+    max-width: 120px;
+
+    img {
+      height: 252px;
+    }
+  }
+
   .filter__list {
     display: block;
     width: 100%;


### PR DESCRIPTION
## Summary
- add internet-sourced advertisement banners around the filter component
- style the filter layout so the banners flank the filter on larger screens and stay responsive on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d447f226e0833288410ba117b0e12c