### PR TITLE
Refine filter ads layout and require Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,14 +28,17 @@
         "@babel/preset-react": "^7.22.5",
         "eslint": "^8.46.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-prettier": "^9.0.0",
-        "eslint-plugin-import": "^2.28.0",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.33.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-config-prettier": "^8.9.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
-        "prettier": "^3.0.1"
+        "prettier": "^3.0.0"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7809,10 +7812,11 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
+      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -18319,14 +18323,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "aviasales",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/src/components/FilterList/FilterList.js
+++ b/src/components/FilterList/FilterList.js
@@ -5,17 +5,68 @@ import "./FilterList.scss";
 
 function FilterList() {
   const filterIds = [1, 2, 3, 4, 5];
+
+  const advertisements = [
+    {
+      position: "left",
+      href: "https://www.emirates.com/ru/russian/",
+      image: {
+        src: "https://images.unsplash.com/photo-1549921296-3ecf9c9e3be0?auto=format&fit=crop&w=400&q=80",
+        alt: "Emirates — специальные тарифы на дальнемагистральные рейсы",
+      },
+    },
+    {
+      position: "right",
+      href: "https://www.qatarairways.com/ru-ru/homepage.html",
+      image: {
+        src: "https://images.unsplash.com/photo-1529074963764-98f45c47344b?auto=format&fit=crop&w=400&q=80",
+        alt: "Qatar Airways — комфортные перелёты в любую точку мира",
+      },
+    },
+  ];
+
+  const getAd = (position) =>
+    advertisements.find((advertisement) => advertisement.position === position);
+
+  const renderAd = (position) => {
+    const advertisement = getAd(position);
+
+    if (!advertisement) {
+      return null;
+    }
+
+    const {
+      href,
+      image: { src, alt },
+    } = advertisement;
+
+    return (
+      <a
+        className={`filter-layout__ad filter-layout__ad--${position}`}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={src} alt={alt} loading="lazy" />
+      </a>
+    );
+  };
+
   return (
-    <aside className="filter">
-      <h3>Количество пересадок</h3>
-      <ul className="filter__list">
-        {filterIds.map((id) => (
-          <li className="filter__item" key={id}>
-            <Filter id={id} />
-          </li>
-        ))}
-      </ul>
-    </aside>
+    <div className="filter-layout">
+      {renderAd("left")}
+      <aside className="filter" aria-label="Фильтр по количеству пересадок">
+        <h3>Количество пересадок</h3>
+        <ul className="filter__list">
+          {filterIds.map((id) => (
+            <li className="filter__item" key={id}>
+              <Filter id={id} />
+            </li>
+          ))}
+        </ul>
+      </aside>
+      {renderAd("right")}
+    </div>
   );
 }
 export default FilterList;

--- a/src/components/FilterList/FilterList.scss
+++ b/src/components/FilterList/FilterList.scss
@@ -1,3 +1,31 @@
+.filter-layout {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.filter-layout__ad {
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  display: block;
+  max-width: 320px;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+
+  img {
+    display: block;
+    height: 200px;
+    object-fit: cover;
+    width: 100%;
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+  }
+}
+
 .filter__list {
   display: flex;
   flex-flow: row wrap;
@@ -30,6 +58,22 @@
 }
 
 @media (min-width: 768px) {
+  .filter-layout {
+    align-items: flex-start;
+    display: grid;
+    gap: 24px;
+    grid-template-columns: 120px auto 120px;
+    justify-items: center;
+  }
+
+  .filter-layout__ad {
+    max-width: 120px;
+
+    img {
+      height: 252px;
+    }
+  }
+
   .filter__list {
     display: block;
     width: 100%;


### PR DESCRIPTION
## Summary
- restructure the filter list ads so each slot renders consistently with lazy-loaded creatives
- annotate the filter panel with an aria label for accessibility improvements
- enforce Node.js 22.x via the package.json engines field to resolve platform warning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d447f226e0833288410ba117b0e12c